### PR TITLE
Add token decimal for proper formatting

### DIFF
--- a/src/district/ui/component/active_account_balance.cljs
+++ b/src/district/ui/component/active_account_balance.cljs
@@ -5,15 +5,17 @@
     [re-frame.core :refer [subscribe]]))
 
 (defn active-account-balance []
-  (fn [{:keys [:contract :token-code :locale :max-fraction-digits :min-fraction-digits]
-        :or {contract :ETH max-fraction-digits 2 min-fraction-digits 0}
+  (fn [{:keys [:contract :token-code :locale :max-fraction-digits :min-fraction-digits :token-decimal]
+        :or {contract :ETH max-fraction-digits 2 min-fraction-digits 0 token-decimal 18}
         :as props}]
     (let [balance @(subscribe [::balances-subs/active-account-balance contract])]
       (when balance
         [:div.active-account-balance
          (dissoc props :contract :token-code :locale :max-fraction-digits :min-fraction-digits)
          [:span.balance
-          (format/format-number balance (merge
+          (format/format-number
+            (/ (js/Number. balance) (js/Math.pow 10 token-decimal))
+            (merge
                                           {:max-fraction-digits max-fraction-digits
                                            :min-fraction-digits min-fraction-digits}
                                           (when locale


### PR DESCRIPTION
Token amount should be divided by the token decimal (usually 1e18) for improving usability.
For example, eth balance will not be shown in wei but in ether.